### PR TITLE
Remove bcrypt version dependency

### DIFF
--- a/acts_as_textcaptcha.gemspec
+++ b/acts_as_textcaptcha.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test}/*`.split("\n")
   s.require_paths = ["lib"]
 
-  s.add_dependency('bcrypt-ruby', '~> 2.1.4')
+  s.add_dependency('bcrypt-ruby')
 
   s.add_development_dependency('rails')
   s.add_development_dependency('bundler')


### PR DESCRIPTION
Rails 3.1+ requires bcrypt ~> 3.0.0, so this causes versioning conflict.
