### PR TITLE
Implement rubocop linter and enforce style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,7 +59,7 @@ AllCops:
   # If a value is specified for TargetRubyVersion then it is used.
   # Else if .ruby-version exists and it contains an MRI version it is used.
   # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
 
 # Indent private/protected/public as deep as method definitions
 Layout/AccessModifierIndentation:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,7 @@ AllCops:
     - "**/Gemfile"
     - "**/Rakefile"
   Exclude:
+    - bin/console
     - "pkg/gems/**/*"
   # Default formatter will be used if no -f/--format option is given.
   DefaultFormatter: progress

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1162 @@
+# Common configuration.
+AllCops:
+  Include:
+    - .simplecov
+    - "**/*.rb"
+    - "**/*.rake"
+    - "**/*.gemspec"
+    - "**/Gemfile"
+    - "**/Rakefile"
+  Exclude:
+    - "pkg/gems/**/*"
+  # Default formatter will be used if no -f/--format option is given.
+  DefaultFormatter: progress
+  # Cop names are not displayed in offense messages by default. Change behavior
+  # by overriding DisplayCopNames, or by giving the -D/--display-cop-names
+  # option.
+  DisplayCopNames: true
+  # Style guide URLs are not displayed in offense messages by default. Change
+  # behavior by overriding DisplayStyleGuide, or by giving the
+  # -S/--display-style-guide option.
+  DisplayStyleGuide: false
+  # Extra details are not displayed in offense messages by default. Change
+  # behavior by overriding ExtraDetails, or by giving the
+  # -E/--extra-details option.
+  ExtraDetails: false
+  # Additional cops that do not reference a style guide rule may be enabled by
+  # default. Change behavior by overriding StyleGuideCopsOnly, or by giving
+  # the --only-guide-cops option.
+  StyleGuideCopsOnly: false
+  # All cops except the ones in disabled.yml are enabled by default. Change
+  # this behavior by overriding DisabledByDefault. When DisabledByDefault is
+  # true, all cops in the default configuration are disabled, and and only cops
+  # in user configuration are enabled. This makes cops opt-in instead of
+  # opt-out. Note that when DisabledByDefault is true, cops in user
+  # configuration will be enabled even if they don't set the Enabled parameter.
+  DisabledByDefault: false
+  # Enables the result cache if true. Can be overridden by the --cache command
+  # line option.
+  UseCache: true
+  # Threshold for how many files can be stored in the result cache before some
+  # of the files are automatically removed.
+  MaxFilesInCache: 20000
+  # The cache will be stored in "rubocop_cache" under this directory. The name
+  # "/tmp" is special and will be converted to the system temporary directory,
+  # which is "/tmp" on Unix-like systems, but could be something else on other
+  # systems.
+  CacheRootDirectory: /tmp
+  # The default cache root directory is /tmp, which on most systems is
+  # writable by any system user. This means that it is possible for a
+  # malicious user to anticipate the location of Rubocop's cache directory,
+  # and create a symlink in its place that could cause Rubocop to overwrite
+  # unintended files, or read malicious input. If you are certain that your
+  # cache location is secure from this kind of attack, and wish to use a
+  # symlinked cache location, set this value to "true".
+  AllowSymlinksInCacheRootDirectory: true
+  # What MRI version of the Ruby interpreter is the inspected code intended to
+  # run on? (If there is more than one, set this to the lowest version.)
+  # If a value is specified for TargetRubyVersion then it is used.
+  # Else if .ruby-version exists and it contains an MRI version it is used.
+  # Otherwise we fallback to the oldest officially supported Ruby version (2.0).
+  TargetRubyVersion: 2.5
+
+# Indent private/protected/public as deep as method definitions
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+    - outdent
+    - indent
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Alias:
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+    - prefer_alias
+    - prefer_alias_method
+
+# Align the elements of a hash literal if they span more than one line.
+Layout/HashAlignment:
+  # Alignment of entries using hash rocket as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   "a" => 2
+  #   "bb" => 3
+  # separator - alignment of hash rockets, keys are right aligned
+  #    "a" => 2
+  #   "bb" => 3
+  # table - left alignment of keys, hash rockets, and values
+  #   "a"  => 2
+  #   "bb" => 3
+  EnforcedHashRocketStyle: key
+  # Alignment of entries using colon as separator. Valid values are:
+  #
+  # key - left alignment of keys
+  #   a: 0
+  #   bb: 1
+  # separator - alignment of colons, keys are right aligned
+  #    a: 0
+  #   bb: 1
+  # table - left alignment of keys and values
+  #   a:  0
+  #   bb: 1
+  EnforcedColonStyle: key
+  # Select whether hashes that are the last argument in a method call should be
+  # inspected? Valid values are:
+  #
+  # always_inspect - Inspect both implicit and explicit hashes.
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # always_ignore - Ignore both implicit and explicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_implicit - Ignore only implicit hashes.
+  #   Accepts:
+  #     function(a: 1,
+  #       b: 2)
+  #   Registers an offense for:
+  #     function({a: 1,
+  #       b: 2})
+  # ignore_explicit - Ignore only explicit hashes.
+  #   Accepts:
+  #     function({a: 1,
+  #       b: 2})
+  #   Registers an offense for:
+  #     function(a: 1,
+  #       b: 2)
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+    - always_inspect
+    - always_ignore
+    - ignore_implicit
+    - ignore_explicit
+
+Layout/ParameterAlignment:
+  # Alignment of parameters in multi-line method calls.
+  #
+  # The `with_first_parameter` style aligns the following lines along the same
+  # column as the first parameter.
+  #
+  #     method_call(a,
+  #                 b)
+  #
+  # The `with_fixed_indentation` style aligns the following lines with one
+  # level of indentation relative to the start of the line with the method call.
+  #
+  #     method_call(a,
+  #       b)
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+    - with_first_parameter
+    - with_fixed_indentation
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/AndOr:
+  # Whether `and` and `or` are banned only in conditionals (conditionals)
+  # or completely (always).
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - conditionals
+
+Style/AsciiComments:
+  Enabled: false
+
+# Checks if usage of %() or %Q() matches configuration.
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+    - percent_q
+    - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+    # The `line_count_based` style enforces braces around single line blocks and
+    # do..end around multi-line blocks.
+    - line_count_based
+    # The `semantic` style enforces braces around functional blocks, where the
+    # primary purpose of the block is to return a value and do..end for
+    # procedural blocks, where the primary purpose of the block is its
+    # side-effects.
+    #
+    # This looks at the usage of a block's method to determine its type (e.g. is
+    # the result of a `map` assigned to a variable or passed to another
+    # method) but exceptions are permitted in the `ProceduralMethods`,
+    # `FunctionalMethods` and `IgnoredMethods` sections below.
+    - semantic
+    # The `braces_for_chaining` style enforces braces around single line blocks
+    # and do..end around multi-line blocks, except for multi-line blocks whose
+    # return value is being chained with another method (in which case braces
+    # are enforced).
+    - braces_for_chaining
+  ProceduralMethods:
+    # Methods that are known to be procedural in nature but look functional from
+    # their usage, e.g.
+    #
+    #   time = Benchmark.realtime do
+    #     foo.bar
+    #   end
+    #
+    # Here, the return value of the block is discarded but the return value of
+    # `Benchmark.realtime` is used.
+    - benchmark
+    - bm
+    - bmbm
+    - create
+    - each_with_object
+    - measure
+    - new
+    - realtime
+    - tap
+    - with_object
+  FunctionalMethods:
+    # Methods that are known to be functional in nature but look procedural from
+    # their usage, e.g.
+    #
+    #   let(:foo) { Foo.new }
+    #
+    # Here, the return value of `Foo.new` is used to define a `foo` helper but
+    # doesn't appear to be used from the return value of `let`.
+    - let
+    - let!
+    - subject
+    - watch
+  IgnoredMethods:
+    # Methods that can be either procedural or functional and cannot be
+    # categorised from their usage alone, e.g.
+    #
+    #   foo = lambda do |x|
+    #     puts "Hello, #{x}"
+    #   end
+    #
+    #   foo = lambda do |x|
+    #     x * 100
+    #   end
+    #
+    # Here, it is impossible to tell from the return value of `lambda` whether
+    # the inner block's return value is significant.
+    - lambda
+    - proc
+    - it
+
+# Indentation of `when`.
+Layout/CaseIndentation:
+  EnforcedStyle: case
+  SupportedStyles:
+    - case
+    - end
+  IndentOneStep: false
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  # This only matters if IndentOneStep is true
+  IndentationWidth: ~
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+  # Checks the style of children definitions at classes and modules.
+  #
+  # Basically there are two different styles:
+  #
+  # `nested` - have each child on a separate line
+  #   class Foo
+  #     class Bar
+  #     end
+  #   end
+  #
+  # `compact` - combine definitions as much as possible
+  #   class Foo::Bar
+  #   end
+  #
+  # The compact style is only forced, for classes / modules with one child.
+  EnforcedStyle: nested
+  SupportedStyles:
+    - nested
+    - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+    - is_a?
+    - kind_of?
+
+# Align with the style guide.
+Style/CollectionMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `detect` over `find`:
+  #
+  # CollectionMethods:
+  #   PreferredMethods:
+  #     find: detect
+  PreferredMethods:
+    collect: "map"
+    collect!: "map!"
+    inject: "reduce"
+    detect: "find"
+    find_all: "select"
+
+# Use ` or %x around command literals.
+Style/CommandLiteral:
+  EnforcedStyle: backticks
+  # backticks: Always use backticks.
+  # percent_x: Always use %x.
+  # mixed: Use backticks on single-line commands, and %x on multi-line commands.
+  SupportedStyles:
+    - backticks
+    - percent_x
+    - mixed
+  # If false, the cop will always recommend using %x if one or more backticks
+  # are found in the command string.
+  AllowInnerBackticks: false
+
+# Checks formatting of special comments
+Style/CommentAnnotation:
+  Keywords:
+    - TODO
+    - FIXME
+    - OPTIMIZE
+    - HACK
+    - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+    - assign_to_condition
+    - assign_inside_condition
+  # When configured to `assign_to_condition`, `SingleLineConditionsOnly`
+  # will only register an offense when all branches of a condition are
+  # a single line.
+  # When configured to `assign_inside_condition`, `SingleLineConditionsOnly`
+  # will only register an offense for assignment to a condition that has
+  # at least one multiline branch.
+  SingleLineConditionsOnly: true
+
+# Checks that you have put a copyright in a comment before any code.
+#
+# You can override the default Notice in your .rubocop.yml file.
+#
+# In order to use autocorrect, you must supply a value for the
+# AutocorrectNotice key that matches the regexp Notice.  A blank
+# AutocorrectNotice will cause an error during autocorrect.
+#
+# Autocorrect will add a copyright notice in a comment at the top
+# of the file immediately after any shebang or encoding comments.
+#
+# Example rubocop.yml:
+#
+# Style/Copyright:
+#   Enabled: true
+#   Notice: 'Copyright (\(c\) )?2015 Yahoo! Inc'
+#   AutocorrectNotice: "# Copyright (c) 2015 Yahoo! Inc."
+#
+Style/Copyright:
+  Notice: '^Copyright (\(c\) )?2[0-9]{3} .+'
+  AutocorrectNotice: ""
+
+Style/DocumentationMethod:
+  RequireForNonPublicMethods: false
+
+# Multi-line method chaining should be done with leading dots.
+Layout/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+    - leading
+    - trailing
+
+# Warn on empty else statements
+# empty - warn only on empty else
+# nil - warn on else with nil in it
+# both - warn on empty else and else with nil in it
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+    - empty
+    - nil
+    - both
+
+# Use empty lines between defs.
+Layout/EmptyLineBetweenDefs:
+  # If true, this parameter means that single line method definitions don't
+  # need an empty line between them.
+  AllowAdjacentOneLineDefs: false
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+    - empty_lines
+    - no_empty_lines
+
+# Checks whether the source file has a utf-8 encoding comment or not
+# AutoCorrectEncodingComment must match the regex
+# /#.*coding\s?[:=]\s?(?:UTF|utf)-8/
+Style/Encoding:
+  Enabled: true
+
+Layout/ExtraSpacing:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: false
+  # When true, forces the alignment of = in assignments on consecutive lines.
+  ForceEqualSignAlignment: false
+
+Naming/FileName:
+  Exclude:
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - "**/*.gemspec"
+  # When true, requires that each source file should define a class or module
+  # with a name which matches the file name (converted to ... case).
+  # It further expects it to be nested inside modules which match the names
+  # of subdirectories in its path.
+  ExpectMatchingDefinition: false
+  # If non-nil, expect all source file names to match the following regex.
+  # Only the file name itself is matched, not the entire file path.
+  # Use anchors as necessary if you want to match the entire name rather than
+  # just a part of it.
+  Regex: ~
+  # With `IgnoreExecutableScripts` set to `true`, this cop does not
+  # report offending filenames for executable scripts (i.e. source
+  # files with a shebang in the first line).
+  IgnoreExecutableScripts: true
+
+Layout/FirstParameterIndentation:
+  EnforcedStyle: align_parentheses
+  SupportedStyles:
+    # The first parameter should always be indented one step more than the
+    # preceding line.
+    - consistent
+    # The first parameter should normally be indented one step more than the
+    # preceding line, but if it's a parameter for a method call that is itself
+    # a parameter in a method call, then the inner parameter should be indented
+    # relative to the inner method.
+    - special_for_inner_method_call
+    # Same as special_for_inner_method_call except that the special rule only
+    # applies if the outer method call encloses its arguments in parentheses.
+    - special_for_inner_method_call_in_parentheses
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks use of for or each in multiline loops.
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+    - for
+    - each
+
+# Enforce the method used for string formatting.
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+    - format
+    - sprintf
+    - percent
+
+Style/FormatStringToken:
+  EnforcedStyle: template
+
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
+# Built-in global variables are allowed by default.
+Style/GlobalVars:
+  AllowedVariables: []
+
+# `MinBodyLength` defines the number of lines of the a body of an if / unless
+# needs to have to trigger this cop
+Style/GuardClause:
+  MinBodyLength: 6
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+    # checks for 1.9 syntax (e.g. {a: 1}) for all symbol keys
+    - ruby19
+    # checks for hash rocket syntax for all hashes
+    - hash_rockets
+    # forbids mixed key syntaxes (e.g. {a: 1, :b => 2})
+    - no_mixed_keys
+    # enforces both ruby19 and no_mixed_keys styles
+    - ruby19_no_mixed_keys
+  # Force hashes that have a symbol value to use hash rockets
+  UseHashRocketsWithSymbolValues: false
+  # Do not suggest { a?: 1 } over { :a? => 1 } in ruby19 style
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Layout/IndentationConsistency:
+  # The difference between `rails` and `normal` is that the `rails` style
+  # prescribes that in classes and modules the `protected` and `private`
+  # modifier keywords shall be indented the same as public methods and that
+  # protected and private members shall be indented one step more than the
+  # modifiers. Other than that, both styles mean that entities on the same
+  # logical depth shall have the same indentation.
+  EnforcedStyle: normal
+  SupportedStyles:
+    - normal
+    - rails
+
+Layout/IndentationWidth:
+  # Number of spaces for each indentation level.
+  Width: 2
+
+# Checks the indentation of the first element in an array literal.
+Layout/FirstArrayElementIndentation:
+  # The value `special_inside_parentheses` means that array literals with
+  # brackets that have their opening bracket on the same line as a surrounding
+  # opening round parenthesis, shall have their first element indented relative
+  # to the first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first element shall
+  # always be relative to the first position of the line where the opening
+  # bracket is.
+  #
+  # The value `align_brackets` means that the indentation of the first element
+  # shall always be relative to the position of the opening bracket.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_brackets
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of assignment RHS, when on a different line from LHS
+Layout/AssignmentIndentation:
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+# Checks the indentation of the first key in a hash literal.
+Layout/FirstHashElementIndentation:
+  # The value `special_inside_parentheses` means that hash literals with braces
+  # that have their opening brace on the same line as a surrounding opening
+  # round parenthesis, shall have their first key indented relative to the
+  # first position inside the parenthesis.
+  #
+  # The value `consistent` means that the indentation of the first key shall
+  # always be relative to the first position of the line where the opening
+  # brace is.
+  #
+  # The value `align_braces` means that the indentation of the first key shall
+  # always be relative to the position of the opening brace.
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+    - special_inside_parentheses
+    - consistent
+    - align_braces
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/Lambda:
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+    - line_count_dependent
+    - lambda
+    - literal
+  Exclude:
+    - "**/types/**/*"
+    - "**/*_interface.rb"
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+    - call
+    - braces
+
+Style/Next:
+  # With `always` all conditions at the end of an iteration needs to be
+  # replaced by next - with `skip_modifier_ifs` the modifier if like this one
+  # are ignored: [1, 2].each { |a| return "yes" if a == 1 }
+  EnforcedStyle: skip_modifier_ifs
+  # `MinBodyLength` defines the number of lines of the a body of an if / unless
+  # needs to have to trigger this cop
+  MinBodyLength: 3
+  SupportedStyles:
+    - skip_modifier_ifs
+    - always
+
+Style/NonNilCheck:
+  # With `IncludeSemanticChanges` set to `true`, this cop reports offenses for
+  # `!x.nil?` and autocorrects that and `x != nil` to solely `x`, which is
+  # **usually** OK, but might change behavior.
+  #
+  # With `IncludeSemanticChanges` set to `false`, this cop does not report
+  # offenses for `!x.nil?` and does no changes that might change behavior.
+  IncludeSemanticChanges: false
+
+Style/NumericPredicate:
+  EnforcedStyle: predicate
+  SupportedStyles:
+    - predicate
+    - comparison
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+    - require_no_parentheses_except_multiline
+
+Naming/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Style/ModuleFunction:
+  EnforcedStyle: module_function
+  SupportedStyles:
+    - module_function
+    - extend_self
+
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineAssignmentLayout:
+  # The types of assignments which are subject to this rule.
+  SupportedTypes:
+    - block
+    - case
+    - class
+    - if
+    - kwbegin
+    - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+    # Ensures that the assignment operator and the rhs are on the same line for
+    # the set of supported types.
+    - same_line
+    # Ensures that the assignment operator and the rhs are on separate lines
+    # for the set of supported types.
+    - new_line
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on same line as last element
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last argument
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+    - indented_relative_to_receiver
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+    # symmetrical: closing brace is positioned in same way as opening brace
+    # new_line: closing brace is always on a new line
+    # same_line: closing brace is always on the same line as last parameter
+    - symmetrical
+    - new_line
+    - same_line
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: aligned
+  SupportedStyles:
+    - aligned
+    - indented
+  # By default, the indentation width from Style/IndentationWidth is used
+  # But it can be overridden by setting this parameter
+  IndentationWidth: ~
+
+Style/NumericLiterals:
+  MinDigits: 5
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+    - zero_with_o
+    - zero_only
+
+Style/OptionHash:
+  # A list of parameter names that will be flagged by this cop.
+  SuspiciousParamNames:
+    - options
+    - opts
+    - args
+    - params
+    - parameters
+
+# Allow safe assignment in conditions.
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    "%":  ()
+    "%i": ()
+    "%q": ()
+    "%Q": ()
+    "%r": "{}"
+    "%s": ()
+    "%w": ()
+    "%W": ()
+    "%x": ()
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+    - lower_case_q # Use %q when possible, %Q when necessary
+    - upper_case_q # Always use %Q
+
+Naming/PredicateName:
+  # Predicate name prefixes.
+  NamePrefix:
+    - is_
+    - has_
+    - have_
+  # Predicate name prefixes that should be removed.
+  ForbiddenPrefixes:
+    - is_
+    - have_
+  # Predicate names which, despite having a forbidden prefix, or no ?,
+  # should still be accepted
+  AllowedMethods:
+    - is_a?
+  # Exclude Rspec specs because there is a strong convetion to write spec
+  # helpers in the form of `have_something` or `be_something`.
+  Exclude:
+    - "**/spec/**/*"
+    - "**/test/**/*"
+
+Style/PreferredHashMethods:
+  Enabled: true
+  EnforcedStyle: verbose
+
+Style/DateTime:
+  Enabled: true
+
+Style/Documentation:
+  Enabled: false
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+    - compact # raise Exception.new(msg)
+    - exploded # raise Exception, msg
+
+Style/RedundantReturn:
+  # When true allows code like `return x, y`.
+  AllowMultipleReturnValues: false
+
+# Use / or %r around regular expressions.
+Style/RegexpLiteral:
+  EnforcedStyle: slashes
+  # slashes: Always use slashes.
+  # percent_r: Always use %r.
+  # mixed: Use slashes on single-line regexes, and %r on multi-line regexes.
+  SupportedStyles:
+    - slashes
+    - percent_r
+    - mixed
+  # If false, the cop will always recommend using %r if one or more slashes
+  # are found in the regexp string.
+  AllowInnerSlashes: false
+
+Style/SafeNavigation:
+  Enabled: false
+
+Style/Semicolon:
+  # Allow ; to separate several expressions on the same line.
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+    - only_raise
+    - only_fail
+    - semantic
+
+Style/SingleLineBlockParams:
+  Methods:
+    - reduce:
+        - a
+        - e
+    - inject:
+        - a
+        - e
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Layout/SpaceBeforeFirstArg:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # things with the previous or next line, not counting empty lines or comment
+  # lines.
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+    - use_perl_names
+    - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+  # If true, strings which span multiple lines using \ for continuation must
+  # use the same type of quotes on each line.
+  ConsistentQuotesInMultiline: false
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+
+Style/StringMethods:
+  # Mapping from undesired method to desired_method
+  # e.g. to use `to_sym` over `intern`:
+  #
+  # StringMethods:
+  #   PreferredMethods:
+  #     intern: to_sym
+  PreferredMethods:
+    intern: to_sym
+
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Layout/SpaceAroundOperators:
+  # When true, allows most uses of extra spacing if the intent is to align
+  # with an operator on the previous or next line, not counting empty lines
+  # or comment lines.
+  AllowForAlignment: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+    - space
+    - no_space
+  # Valid values are: space, no_space
+  EnforcedStyleForEmptyBraces: no_space
+  # Space between { and |. Overrides EnforcedStyle if there is a conflict.
+  SpaceBeforeBlockParameters: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+    - space
+    - no_space
+    # "compact" normally requires a space inside hash braces, with the exception
+    # that successive left braces or right braces are collapsed together
+    - compact
+
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+    - space
+    - no_space
+
+Style/AccessModifierDeclarations:
+  Enabled: false
+
+Style/SymbolArray:
+  EnforcedStyle: brackets
+  SupportedStyles:
+    - percent
+    - brackets
+
+Style/SymbolProc:
+  # A list of method names to be ignored by the check.
+  # The names should be fairly unique, otherwise you'll end up ignoring lots of code.
+  IgnoredMethods:
+    - respond_to
+    - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+    - require_parentheses
+    - require_no_parentheses
+  AllowSafeAssignment: true
+
+Layout/TrailingEmptyLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+    - final_newline
+    - final_blank_line
+
+Style/TrailingCommaInArguments:
+  # If `comma`, the cop requires a comma after the last argument, but only for
+  # parenthesized method calls where each argument is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last argument,
+  # for all parenthesized method calls with arguments.
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInArrayLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
+  EnforcedStyleForMultiline: no_comma
+
+Style/TrailingCommaInHashLiteral:
+  # If `comma`, the cop requires a comma after the last item in an array or
+  # hash, but only when each item is on its own line.
+  # If `consistent_comma`, the cop requires a comma after the last item of all
+  # non-empty array and hash literals.
+  EnforcedStyleForMultiline: no_comma
+
+# TrivialAccessors requires exact name matches and doesn't allow
+# predicated methods by default.
+Style/TrivialAccessors:
+  # When set to false the cop will suggest the use of accessor methods
+  # in situations like:
+  #
+  # def name
+  #   @other_name
+  # end
+  #
+  # This way you can uncover "hidden" attributes in your code.
+  ExactNameMatch: true
+  AllowPredicates: true
+  # Allows trivial writers that don't end in an equal sign. e.g.
+  #
+  # def on_exception(action)
+  #   @on_exception=action
+  # end
+  # on_exception :restart
+  #
+  # Commonly used in DSLs
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  AllowedMethods:
+    - to_ary
+    - to_a
+    - to_c
+    - to_enum
+    - to_h
+    - to_hash
+    - to_i
+    - to_int
+    - to_io
+    - to_open
+    - to_path
+    - to_proc
+    - to_r
+    - to_regexp
+    - to_str
+    - to_s
+    - to_sym
+
+Naming/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+    - snake_case
+    - camelCase
+
+Naming/VariableNumber:
+  EnforcedStyle: normalcase
+  SupportedStyles:
+    - snake_case
+    - normalcase
+    - non_integer
+
+# WordArray enforces how array literals of word-like strings should be expressed.
+Style/WordArray:
+  EnforcedStyle: percent
+  SupportedStyles:
+    # percent style: %w(word1 word2)
+    - percent
+    # bracket style: ["word1", "word2"]
+    - brackets
+  # The MinSize option causes the WordArray rule to be ignored for arrays
+  # smaller than a certain size.  The rule is only applied to arrays
+  # whose element count is greater than or equal to MinSize.
+  MinSize: 2
+  # The regular expression WordRegex decides what is considered a word.
+  WordRegex: !ruby/regexp '/\A[\p{Word}\n\t]+\z/'
+
+##################### Metrics ##################################
+
+Metrics/AbcSize:
+  # The ABC size is a calculated magnitude, so this number can be an Integer or
+  # a Float.
+  Max: 15
+  Enabled: false
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/ClassLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+  Enabled: false
+
+Metrics/ModuleLength:
+  CountComments: false  # count full line comments?
+  Max: 100
+  Enabled: false
+
+# Avoid complex methods.
+Metrics/CyclomaticComplexity:
+  Max: 9
+  Exclude:
+    - "**/*/permissions.rb"
+
+Layout/LineLength:
+  Max: 180
+  # To make it possible to copy or click on URIs in the code, we allow lines
+  # containing a URI to be longer than Max.
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+    - http
+    - https
+  Exclude:
+    - "**/spec/**/*"
+    - "decidim-generators/pkg/**/*"
+    - "pkg/**/*"
+
+Metrics/MethodLength:
+  CountComments: false  # count full line comments?
+  Max: 15
+  Enabled: false
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: true
+  Exclude:
+    - "decidim-core/lib/decidim/filter_form_builder.rb"
+
+Metrics/PerceivedComplexity:
+  Max: 10
+  Exclude:
+    - "**/*/permissions.rb"
+
+##################### Lint ##################################
+
+Lint/AmbiguousBlockAssociation:
+  Enabled: true
+  Exclude:
+    - "**/abilities/**/*"
+
+# Allow safe assignment in conditions.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: true
+
+# checks whether the end keywords are aligned properly for `do` `end` blocks.
+Layout/BlockAlignment:
+  # The value `start_of_block` means that the `end` should be aligned with line
+  # where the `do` keyword appears.
+  # The value `start_of_line` means it should be aligned with the whole
+  # expression's starting line.
+  # The value `either` means both are allowed.
+  EnforcedStyleAlignWith: either
+
+# Align ends correctly.
+Layout/EndAlignment:
+  # The value `keyword` means that `end` should be aligned with the matching
+  # keyword (if, while, etc.).
+  # The value `variable` means that in assignments, `end` should be aligned
+  # with the start of the variable on the left hand side of `=`. In all other
+  # situations, `end` should still be aligned with the keyword.
+  # The value `start_of_line` means that `end` should be aligned with the start
+  # of the line which the matching keyword appears on.
+  EnforcedStyleAlignWith: keyword
+  AutoCorrect: false
+
+Layout/DefEndAlignment:
+  # The value `def` means that `end` should be aligned with the def keyword.
+  # The value `start_of_line` means that `end` should be aligned with method
+  # calls like `private`, `public`, etc, if present in front of the `def`
+  # keyword on the same line.
+  EnforcedStyleAlignWith: start_of_line
+  AutoCorrect: false
+
+Lint/InheritException:
+  # The default base class in favour of `Exception`.
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+    - runtime_error
+    - standard_error
+
+# Checks for unused block arguments
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+# Checks for unused method arguments.
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+##################### Performance ############################
+
+Metrics/BlockLength:
+  Enabled: false

--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,6 @@
 SimpleCov.start do
-  add_filter '/test/'
-  add_filter '/vendor/'
+  add_filter "/test/"
+  add_filter "/vendor/"
 end
 
 SimpleCov.at_exit do

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   add_filter "/test/"
   add_filter "/vendor/"

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 require "rdoc/task"

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,14 @@
-require 'bundler/gem_tasks'
-require 'rake/testtask'
+require "bundler/gem_tasks"
+require "rake/testtask"
 require "rdoc/task"
-require 'rubocop/rake_task'
+require "rubocop/rake_task"
 
 # generate docs
 RDoc::Task.new do |rd|
-  rd.main     = "README.md"
-  rd.title    = 'ActsAsTextcaptcha'
-  rd.rdoc_dir = 'doc'
-  rd.options  << "--all"
+  rd.main = "README.md"
+  rd.title = "ActsAsTextcaptcha"
+  rd.rdoc_dir = "doc"
+  rd.options << "--all"
   rd.rdoc_files.include("README.md", "LICENSE", "lib/**/*.rb")
 end
 
@@ -21,17 +21,17 @@ end
 
 # Run lint
 RuboCop::RakeTask.new(:rubocop) do |t|
-  t.options = ['--display-cop-names']
+  t.options = ["--display-cop-names"]
 end
 
 # run tests with code coverage (default)
 namespace :test do
   desc "Run all tests and features and generate a code coverage report"
   task :coverage do
-    ENV['COVERAGE'] = 'true'
-    Rake::Task['test'].execute
-    Rake::Task['rubocop'].execute
+    ENV["COVERAGE"] = "true"
+    Rake::Task["test"].execute
+    Rake::Task["rubocop"].execute
   end
 end
 
-task :default => ['test:coverage']
+task default: ["test:coverage"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require "rdoc/task"
+require 'rubocop/rake_task'
 
 # generate docs
 RDoc::Task.new do |rd|
@@ -18,12 +19,18 @@ Rake::TestTask.new(:test) do |t|
   t.test_files = FileList["test/**/*_test.rb"]
 end
 
+# Run lint
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+
 # run tests with code coverage (default)
 namespace :test do
   desc "Run all tests and features and generate a code coverage report"
   task :coverage do
     ENV['COVERAGE'] = 'true'
     Rake::Task['test'].execute
+    Rake::Task['rubocop'].execute
   end
 end
 

--- a/acts_as_textcaptcha.gemspec
+++ b/acts_as_textcaptcha.gemspec
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'acts_as_textcaptcha/version'
+require "acts_as_textcaptcha/version"
 
 Gem::Specification.new do |spec|
-  spec.name     = 'acts_as_textcaptcha'
-  spec.version  = ActsAsTextcaptcha::VERSION
-  spec.authors  = ['Matthew Hutchinson']
-  spec.email    = ['matt@hiddenloop.com']
-  spec.homepage = 'http://github.com/matthutchinson/acts_as_textcaptcha'
-  spec.license  = 'MIT'
-  spec.summary  = 'A text-based logic question captcha for Rails'
+  spec.name = "acts_as_textcaptcha"
+  spec.version = ActsAsTextcaptcha::VERSION
+  spec.authors = ["Matthew Hutchinson"]
+  spec.email = ["matt@hiddenloop.com"]
+  spec.homepage = "http://github.com/matthutchinson/acts_as_textcaptcha"
+  spec.license = "MIT"
+  spec.summary = "A text-based logic question captcha for Rails"
 
   spec.description = <<-DESCRIPTION
   ActsAsTextcaptcha provides spam protection for Rails models with text-based
@@ -21,41 +21,41 @@ Gem::Specification.new do |spec|
   DESCRIPTION
 
   spec.metadata = {
-    'homepage_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha',
-    'changelog_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha/blob/master/CHANGELOG.md',
-    'source_code_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha',
-    'bug_tracker_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha/issues',
-    'allowed_push_host' => 'https://rubygems.org'
+    "homepage_uri" => "https://github.com/matthutchinson/acts_as_textcaptcha",
+    "changelog_uri" => "https://github.com/matthutchinson/acts_as_textcaptcha/blob/master/CHANGELOG.md",
+    "source_code_uri" => "https://github.com/matthutchinson/acts_as_textcaptcha",
+    "bug_tracker_uri" => "https://github.com/matthutchinson/acts_as_textcaptcha/issues",
+    "allowed_push_host" => "https://rubygems.org"
   }
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.test_files    = `git ls-files -- {test}/*`.split("\n")
-  spec.bindir        = 'bin'
-  spec.require_paths = ['lib']
+  spec.files = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.test_files = `git ls-files -- {test}/*`.split("\n")
+  spec.bindir = "bin"
+  spec.require_paths = ["lib"]
 
   # documentation
-  spec.extra_rdoc_files = ['README.md', 'LICENSE']
-  spec.rdoc_options << '--title' << 'ActAsTextcaptcha' << '--main' << 'README.md' << '-ri'
+  spec.extra_rdoc_files = ["README.md", "LICENSE"]
+  spec.rdoc_options << "--title" << "ActAsTextcaptcha" << "--main" << "README.md" << "-ri"
 
   # non-gem dependecies
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = ">= 2.4"
 
   # dev gems
-  spec.add_development_dependency('bundler')
-  spec.add_development_dependency('pry-byebug')
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency("bundler")
+  spec.add_development_dependency("pry-byebug")
+  spec.add_development_dependency "rake"
 
   # Lint
-  spec.add_development_dependency('rubocop')
+  spec.add_development_dependency("rubocop")
 
   # docs
-  spec.add_development_dependency('rdoc')
+  spec.add_development_dependency("rdoc")
 
   # testing
-  spec.add_development_dependency('appraisal')
-  spec.add_development_dependency('minitest')
-  spec.add_development_dependency('rails', '~> 6.0.2.1')
-  spec.add_development_dependency('simplecov', '~> 0.17.1')
-  spec.add_development_dependency('sqlite3')
-  spec.add_development_dependency('webmock')
+  spec.add_development_dependency("appraisal")
+  spec.add_development_dependency("minitest")
+  spec.add_development_dependency("rails", "~> 6.0.2.1")
+  spec.add_development_dependency("simplecov", "~> 0.17.1")
+  spec.add_development_dependency("sqlite3")
+  spec.add_development_dependency("webmock")
 end

--- a/acts_as_textcaptcha.gemspec
+++ b/acts_as_textcaptcha.gemspec
@@ -1,56 +1,61 @@
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "acts_as_textcaptcha/version"
+require 'acts_as_textcaptcha/version'
 
 Gem::Specification.new do |spec|
-  spec.name     = "acts_as_textcaptcha"
+  spec.name     = 'acts_as_textcaptcha'
   spec.version  = ActsAsTextcaptcha::VERSION
-  spec.authors  = ["Matthew Hutchinson"]
-  spec.email    = ["matt@hiddenloop.com"]
-  spec.homepage = "http://github.com/matthutchinson/acts_as_textcaptcha"
+  spec.authors  = ['Matthew Hutchinson']
+  spec.email    = ['matt@hiddenloop.com']
+  spec.homepage = 'http://github.com/matthutchinson/acts_as_textcaptcha'
   spec.license  = 'MIT'
-  spec.summary  = "A text-based logic question captcha for Rails"
+  spec.summary  = 'A text-based logic question captcha for Rails'
 
-  spec.description = <<-EOF
+  spec.description = <<-DESCRIPTION
   ActsAsTextcaptcha provides spam protection for Rails models with text-based
   logic question captchas. Questions are fetched from Rob Tuley's
   textcaptcha.com They can be solved easily by humans but are tough for robots
   to crack.
-  EOF
+  DESCRIPTION
 
   spec.metadata = {
-    "homepage_uri"      => "https://github.com/matthutchinson/acts_as_textcaptcha",
-    "changelog_uri"     => "https://github.com/matthutchinson/acts_as_textcaptcha/blob/master/CHANGELOG.md",
-    "source_code_uri"   => "https://github.com/matthutchinson/acts_as_textcaptcha",
-    "bug_tracker_uri"   => "https://github.com/matthutchinson/acts_as_textcaptcha/issues",
-    "allowed_push_host" => "https://rubygems.org"
+    'homepage_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha',
+    'changelog_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha',
+    'bug_tracker_uri' => 'https://github.com/matthutchinson/acts_as_textcaptcha/issues',
+    'allowed_push_host' => 'https://rubygems.org'
   }
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.test_files    = `git ls-files -- {test}/*`.split("\n")
-  spec.bindir        = "bin"
-  spec.require_paths = ["lib"]
+  spec.bindir        = 'bin'
+  spec.require_paths = ['lib']
 
   # documentation
-  spec.extra_rdoc_files = ["README.md", "LICENSE"]
-  spec.rdoc_options << "--title" << "ActAsTextcaptcha" << "--main" << "README.md" << "-ri"
+  spec.extra_rdoc_files = ['README.md', 'LICENSE']
+  spec.rdoc_options << '--title' << 'ActAsTextcaptcha' << '--main' << 'README.md' << '-ri'
 
   # non-gem dependecies
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = '>= 2.4'
 
   # dev gems
   spec.add_development_dependency('bundler')
-  spec.add_development_dependency "rake"
   spec.add_development_dependency('pry-byebug')
+  spec.add_development_dependency 'rake'
+
+  # Lint
+  spec.add_development_dependency('rubocop')
 
   # docs
   spec.add_development_dependency('rdoc')
 
   # testing
-  spec.add_development_dependency('rails', '~> 6.0.2.1')
+  spec.add_development_dependency('appraisal')
   spec.add_development_dependency('minitest')
+  spec.add_development_dependency('rails', '~> 6.0.2.1')
+  spec.add_development_dependency('simplecov', '~> 0.17.1')
   spec.add_development_dependency('sqlite3')
   spec.add_development_dependency('webmock')
-  spec.add_development_dependency('simplecov', '~> 0.17.1')
-  spec.add_development_dependency('appraisal')
 end

--- a/lib/acts_as_textcaptcha.rb
+++ b/lib/acts_as_textcaptcha.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'acts_as_textcaptcha/version'
-require 'acts_as_textcaptcha/errors'
-require 'acts_as_textcaptcha/textcaptcha'
-require 'acts_as_textcaptcha/textcaptcha_config'
-require 'acts_as_textcaptcha/textcaptcha_helper'
-require 'acts_as_textcaptcha/framework/rails'
-require 'acts_as_textcaptcha/railtie' if defined?(Rails::Railtie)
+require "acts_as_textcaptcha/version"
+require "acts_as_textcaptcha/errors"
+require "acts_as_textcaptcha/textcaptcha"
+require "acts_as_textcaptcha/textcaptcha_config"
+require "acts_as_textcaptcha/textcaptcha_helper"
+require "acts_as_textcaptcha/framework/rails"
+require "acts_as_textcaptcha/railtie" if defined?(Rails::Railtie)

--- a/lib/acts_as_textcaptcha/railtie.rb
+++ b/lib/acts_as_textcaptcha/railtie.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-#
+
 module ActsAsTextcaptcha
   class Railtie < Rails::Railtie
     rake_tasks do
-      Dir[File.join(File.dirname(__FILE__), '/tasks/*.rake')].each { |f| load f }
+      Dir[File.join(File.dirname(__FILE__), "/tasks/*.rake")].each { |f| load f }
     end
   end
 end

--- a/lib/acts_as_textcaptcha/tasks/textcaptcha.rake
+++ b/lib/acts_as_textcaptcha/tasks/textcaptcha.rake
@@ -1,11 +1,10 @@
-require 'rails'
-require 'acts_as_textcaptcha/textcaptcha_config'
+require "rails"
+require "acts_as_textcaptcha/textcaptcha_config"
 
 namespace :textcaptcha do
-
   desc "Creates an example textcaptcha config at config/textcaptcha.yml"
   task :config do
-    path = File.join((Rails.root ? Rails.root : '.'), 'config', 'textcaptcha.yml')
+    path = File.join((Rails.root || "."), "config", "textcaptcha.yml")
     if File.exist?(path)
       puts "Ooops, a textcaptcha config file at #{path} already exists ... aborting."
     else

--- a/lib/acts_as_textcaptcha/tasks/textcaptcha.rake
+++ b/lib/acts_as_textcaptcha/tasks/textcaptcha.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails"
 require "acts_as_textcaptcha/textcaptcha_config"
 

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -50,11 +50,11 @@ module ActsAsTextcaptcha
       end
 
       def config_q_and_a
-        if textcaptcha_config[:questions]
-          random_question = textcaptcha_config[:questions][rand(textcaptcha_config[:questions].size)].symbolize_keys!
-          answers = (random_question[:answers] || "").split(",").map! { |answer| safe_md5(answer) }
-          { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
-        end
+        return unless textcaptcha_config[:questions]
+
+        random_question = textcaptcha_config[:questions][rand(textcaptcha_config[:questions].size)].symbolize_keys!
+        answers = (random_question[:answers] || "").split(",").map! { |answer| safe_md5(answer) }
+        { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
       end
 
       # check textcaptcha, if incorrect, generate a new textcaptcha
@@ -134,6 +134,7 @@ module ActsAsTextcaptcha
     rescue StandardError
       raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"
     end
+
     # rubocop:enable Security/YAMLLoad
 
     def read_textcaptcha_config

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -128,7 +128,7 @@ module ActsAsTextcaptcha
       if options.is_a?(Hash)
         options
       else
-        YAML.safe_load(ERB.new(read_textcaptcha_config).result)[Rails.env]
+        YAML.load(ERB.new(read_textcaptcha_config).result)[Rails.env]
       end
     rescue StandardError
       raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -126,7 +126,7 @@ module ActsAsTextcaptcha
       if options.is_a?(Hash)
         options
       else
-        YAML.load(ERB.new(read_textcaptcha_config).result)[Rails.env]
+        YAML.safe_load(ERB.new(read_textcaptcha_config).result)[Rails.env]
       end
     rescue StandardError
       raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -1,22 +1,19 @@
 # frozen_string_literal: true
 
-require 'yaml'
-require 'net/http'
-require 'digest/md5'
-require 'acts_as_textcaptcha/textcaptcha_cache'
-require 'acts_as_textcaptcha/textcaptcha_api'
+require "yaml"
+require "net/http"
+require "digest/md5"
+require "acts_as_textcaptcha/textcaptcha_cache"
+require "acts_as_textcaptcha/textcaptcha_api"
 
 module ActsAsTextcaptcha
   module Textcaptcha
-
     def acts_as_textcaptcha(options = nil)
       cattr_accessor :textcaptcha_config
       attr_accessor :textcaptcha_question, :textcaptcha_answer, :textcaptcha_key
 
       # ensure these attrs are accessible (Rails 3)
-      if respond_to?(:accessible_attributes) && respond_to?(:attr_accessible)
-        attr_accessible :textcaptcha_answer, :textcaptcha_key
-      end
+      attr_accessible :textcaptcha_answer, :textcaptcha_key if respond_to?(:accessible_attributes) && respond_to?(:attr_accessible)
 
       self.textcaptcha_config = build_textcaptcha_config(options).symbolize_keys!
 
@@ -26,122 +23,117 @@ module ActsAsTextcaptcha
     end
 
     module InstanceMethods
-
       # override this method to toggle textcaptcha checking, by default this
       # will only allow new records to be protected with textcaptchas
       def perform_textcaptcha?
-        (!respond_to?('new_record?') || new_record?)
+        (!respond_to?("new_record?") || new_record?)
       end
 
       def textcaptcha
-        if perform_textcaptcha? && textcaptcha_config
-          assign_textcaptcha(fetch_q_and_a || config_q_and_a)
-        end
+        assign_textcaptcha(fetch_q_and_a || config_q_and_a) if perform_textcaptcha? && textcaptcha_config
       end
-
 
       private
 
-        def fetch_q_and_a
-          return unless should_fetch?
+      def fetch_q_and_a
+        return unless should_fetch?
 
-          TextcaptchaApi.new(
-            api_key: textcaptcha_config[:api_key],
-            api_endpoint: textcaptcha_config[:api_endpoint],
-            raise_errors: textcaptcha_config[:raise_errors]
-          ).fetch
+        TextcaptchaApi.new(
+          api_key: textcaptcha_config[:api_key],
+          api_endpoint: textcaptcha_config[:api_endpoint],
+          raise_errors: textcaptcha_config[:raise_errors]
+        ).fetch
+      end
+
+      def should_fetch?
+        textcaptcha_config[:api_key] || textcaptcha_config[:api_endpoint]
+      end
+
+      def config_q_and_a
+        if textcaptcha_config[:questions]
+          random_question = textcaptcha_config[:questions][rand(textcaptcha_config[:questions].size)].symbolize_keys!
+          answers = (random_question[:answers] || "").split(",").map! { |answer| safe_md5(answer) }
+          { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
         end
+      end
 
-        def should_fetch?
-          textcaptcha_config[:api_key] || textcaptcha_config[:api_endpoint]
-        end
-
-        def config_q_and_a
-          if textcaptcha_config[:questions]
-            random_question = textcaptcha_config[:questions][rand(textcaptcha_config[:questions].size)].symbolize_keys!
-            answers = (random_question[:answers] || '').split(',').map!{ |answer| safe_md5(answer) }
-            if random_question && answers.present?
-              { 'q' => random_question[:question], 'a' => answers }
-            end
-          end
-        end
-
-        # check textcaptcha, if incorrect, generate a new textcaptcha
-        def validate_textcaptcha
-          valid_answers = textcaptcha_cache.read(textcaptcha_key) || []
-          reset_textcaptcha
-          if valid_answers.include?(safe_md5(textcaptcha_answer))
-            # answer was valid, mutate the key again
-            self.textcaptcha_key = textcaptcha_random_key
-            textcaptcha_cache.write(textcaptcha_key, valid_answers, textcaptcha_cache_options)
-            true
-          else
-            add_textcaptcha_error(too_slow: valid_answers.empty?)
-            textcaptcha
-            false
-          end
-        end
-
-        def add_textcaptcha_error(too_slow: false)
-          if too_slow
-            errors.add(:textcaptcha_answer, :expired, :message => 'was not submitted quickly enough, try another question instead')
-          else
-            errors.add(:textcaptcha_answer, :incorrect, :message => 'is incorrect, try another question instead')
-          end
-        end
-
-        def reset_textcaptcha
-          if textcaptcha_key
-            textcaptcha_cache.delete(textcaptcha_key)
-            self.textcaptcha_key = nil
-          end
-        end
-
-        def assign_textcaptcha(q_and_a)
-          return unless q_and_a
-          self.textcaptcha_question = q_and_a['q']
+      # check textcaptcha, if incorrect, generate a new textcaptcha
+      def validate_textcaptcha
+        valid_answers = textcaptcha_cache.read(textcaptcha_key) || []
+        reset_textcaptcha
+        if valid_answers.include?(safe_md5(textcaptcha_answer))
+          # answer was valid, mutate the key again
           self.textcaptcha_key = textcaptcha_random_key
-          textcaptcha_cache.write(textcaptcha_key, q_and_a['a'], textcaptcha_cache_options)
+          textcaptcha_cache.write(textcaptcha_key, valid_answers, textcaptcha_cache_options)
+          true
+        else
+          add_textcaptcha_error(too_slow: valid_answers.empty?)
+          textcaptcha
+          false
         end
+      end
 
-        # strip whitespace pass through mb_chars (a multibyte safe proxy for
-        # strings) then downcase
-        def safe_md5(answer)
-          Digest::MD5.hexdigest(answer.to_s.strip.mb_chars.downcase)
+      def add_textcaptcha_error(too_slow: false)
+        if too_slow
+          errors.add(:textcaptcha_answer, :expired, message: "was not submitted quickly enough, try another question instead")
+        else
+          errors.add(:textcaptcha_answer, :incorrect, message: "is incorrect, try another question instead")
         end
+      end
 
-        # a random cache key, time based, random
-        def textcaptcha_random_key
-          safe_md5(Time.now.to_i + rand(1_000_000))
+      def reset_textcaptcha
+        if textcaptcha_key
+          textcaptcha_cache.delete(textcaptcha_key)
+          self.textcaptcha_key = nil
         end
+      end
 
-        def textcaptcha_cache_options
-          if textcaptcha_config[:cache_expiry_minutes]
-            { :expires_in => textcaptcha_config[:cache_expiry_minutes].to_f.minutes }
-          else
-            {}
-          end
-        end
+      def assign_textcaptcha(q_and_a)
+        return unless q_and_a
 
-        def textcaptcha_cache
-          @@textcaptcha_cache ||= TextcaptchaCache.new
+        self.textcaptcha_question = q_and_a["q"]
+        self.textcaptcha_key = textcaptcha_random_key
+        textcaptcha_cache.write(textcaptcha_key, q_and_a["a"], textcaptcha_cache_options)
+      end
+
+      # strip whitespace pass through mb_chars (a multibyte safe proxy for
+      # strings) then downcase
+      def safe_md5(answer)
+        Digest::MD5.hexdigest(answer.to_s.strip.mb_chars.downcase)
+      end
+
+      # a random cache key, time based, random
+      def textcaptcha_random_key
+        safe_md5(Time.now.to_i + rand(1_000_000))
+      end
+
+      def textcaptcha_cache_options
+        if textcaptcha_config[:cache_expiry_minutes]
+          { expires_in: textcaptcha_config[:cache_expiry_minutes].to_f.minutes }
+        else
+          {}
         end
+      end
+
+      def textcaptcha_cache
+        @@textcaptcha_cache ||= TextcaptchaCache.new
+      end
     end
 
     private
 
-      def build_textcaptcha_config(options)
-        if options.is_a?(Hash)
-          options
-        else
-          YAML.load(ERB.new(read_textcaptcha_config).result)[Rails.env]
-        end
-      rescue
-        raise ArgumentError.new('could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file')
+    def build_textcaptcha_config(options)
+      if options.is_a?(Hash)
+        options
+      else
+        YAML.load(ERB.new(read_textcaptcha_config).result)[Rails.env]
       end
+    rescue StandardError
+      raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"
+    end
 
-      def read_textcaptcha_config
-        File.read("#{Rails.root ? Rails.root : '.'}/config/textcaptcha.yml")
-      end
+    def read_textcaptcha_config
+      File.read("#{Rails.root || "."}/config/textcaptcha.yml")
+    end
   end
 end

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -134,7 +134,6 @@ module ActsAsTextcaptcha
     rescue StandardError
       raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"
     end
-
     # rubocop:enable Security/YAMLLoad
 
     def read_textcaptcha_config

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -115,9 +115,11 @@ module ActsAsTextcaptcha
         end
       end
 
+      # rubocop:disable Style/ClassVars
       def textcaptcha_cache
         @@textcaptcha_cache ||= TextcaptchaCache.new
       end
+      # rubocop:enable Style/ClassVars
     end
 
     private

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -124,6 +124,7 @@ module ActsAsTextcaptcha
 
     private
 
+    # rubocop:disable Security/YAMLLoad
     def build_textcaptcha_config(options)
       if options.is_a?(Hash)
         options
@@ -133,6 +134,7 @@ module ActsAsTextcaptcha
     rescue StandardError
       raise ArgumentError, "could not find any textcaptcha options, in config/textcaptcha.yml or model - run rake textcaptcha:config to generate a template config file"
     end
+    # rubocop:enable Security/YAMLLoad
 
     def read_textcaptcha_config
       File.read("#{Rails.root || "."}/config/textcaptcha.yml")

--- a/lib/acts_as_textcaptcha/textcaptcha.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha.rb
@@ -53,7 +53,7 @@ module ActsAsTextcaptcha
         return unless textcaptcha_config[:questions]
 
         random_question = textcaptcha_config[:questions][rand(textcaptcha_config[:questions].size)].symbolize_keys!
-        answers = (random_question[:answers] || "").split(",").map! { |answer| safe_md5(answer) }
+        answers = (random_question[:answers] || "").split(",").map { |answer| safe_md5(answer) }
         { "q" => random_question[:question], "a" => answers } if random_question && answers.present?
       end
 

--- a/lib/acts_as_textcaptcha/textcaptcha_api.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_api.rb
@@ -33,9 +33,9 @@ module ActsAsTextcaptcha
         handle_error ResponseError.new(uri, "status: #{response.code}")
       end
     rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
-           Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-           Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
-           Net::ProtocolError => e
+        Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
+        Net::ProtocolError => e
       handle_error ResponseError.new(uri, e)
     end
 
@@ -46,12 +46,10 @@ module ActsAsTextcaptcha
     end
 
     def handle_error(error)
-      if raise_errors
-        raise error
-      else
-        Rails.logger.error("#{error.class} #{error.message}")
-        nil
-      end
+      raise error if raise_errors
+
+      Rails.logger.error("#{error.class} #{error.message}")
+      nil
     end
   end
 end

--- a/lib/acts_as_textcaptcha/textcaptcha_api.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_api.rb
@@ -33,9 +33,9 @@ module ActsAsTextcaptcha
         handle_error ResponseError.new(uri, "status: #{response.code}")
       end
     rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
-        Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
-        Net::ProtocolError => e
+           Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+           Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
+           Net::ProtocolError => e
       handle_error ResponseError.new(uri, e)
     end
 

--- a/lib/acts_as_textcaptcha/textcaptcha_api.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_api.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
-require 'json'
+require "json"
 
 module ActsAsTextcaptcha
   class TextcaptchaApi
-
-    BASE_URL = 'http://textcaptcha.com'
+    BASE_URL = "http://textcaptcha.com"
 
     def initialize(api_key: nil, api_endpoint: nil, raise_errors: false)
-      if api_endpoint
-        self.uri = URI(api_endpoint)
-      else
-        self.uri = URI("#{BASE_URL}/#{api_key}.json")
-      end
+      self.uri = if api_endpoint
+                   URI(api_endpoint)
+                 else
+                   URI("#{BASE_URL}/#{api_key}.json")
+                 end
       self.raise_errors = raise_errors || false
-    rescue URI::InvalidURIError => exception
-      raise ApiKeyError.new(api_key, exception)
+    rescue URI::InvalidURIError => e
+      raise ApiKeyError.new(api_key, e)
     end
 
     def fetch
@@ -24,35 +23,35 @@ module ActsAsTextcaptcha
 
     private
 
-      attr_accessor :uri, :raise_errors
+    attr_accessor :uri, :raise_errors
 
-      def get
-        response = Net::HTTP.new(uri.host, uri.port).get(uri.path)
-        if response.code == '200'
-          response.body
-        else
-          handle_error ResponseError.new(uri, "status: #{response.code}")
-        end
-      rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
-        Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
-        Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
-        Net::ProtocolError => exception
-        handle_error ResponseError.new(uri, exception)
+    def get
+      response = Net::HTTP.new(uri.host, uri.port).get(uri.path)
+      if response.code == "200"
+        response.body
+      else
+        handle_error ResponseError.new(uri, "status: #{response.code}")
       end
+    rescue SocketError, Timeout::Error, Errno::EINVAL, Errno::ECONNRESET,
+           Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
+           Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError,
+           Net::ProtocolError => e
+      handle_error ResponseError.new(uri, e)
+    end
 
-      def parse(response)
-        JSON.parse(response) unless response.empty?
-      rescue JSON::ParserError
-        handle_error ParseError.new(uri)
-      end
+    def parse(response)
+      JSON.parse(response) unless response.empty?
+    rescue JSON::ParserError
+      handle_error ParseError.new(uri)
+    end
 
-      def handle_error(error)
-        if raise_errors
-          raise error
-        else
-          Rails.logger.error("#{error.class} #{error.message}")
-          nil
-        end
+    def handle_error(error)
+      if raise_errors
+        raise error
+      else
+        Rails.logger.error("#{error.class} #{error.message}")
+        nil
       end
+    end
   end
 end

--- a/lib/acts_as_textcaptcha/textcaptcha_cache.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_cache.rb
@@ -5,14 +5,11 @@
 
 module ActsAsTextcaptcha
   class TextcaptchaCache
-
-    KEY_PREFIX = 'acts_as_textcaptcha-'
+    KEY_PREFIX = "acts_as_textcaptcha-"
     DEFAULT_EXPIRY_MINUTES = 10
 
     def write(key, value, options = {})
-      unless options.has_key?(:expires_in)
-        options[:expires_in] = DEFAULT_EXPIRY_MINUTES.minutes
-      end
+      options[:expires_in] = DEFAULT_EXPIRY_MINUTES.minutes unless options.has_key?(:expires_in)
       Rails.cache.write(cache_key(key), value, options)
     end
 
@@ -26,8 +23,8 @@ module ActsAsTextcaptcha
 
     private
 
-      def cache_key(key)
-        "#{KEY_PREFIX}#{key}"
-      end
+    def cache_key(key)
+      "#{KEY_PREFIX}#{key}"
+    end
   end
 end

--- a/lib/acts_as_textcaptcha/textcaptcha_config.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_config.rb
@@ -2,47 +2,46 @@
 
 module ActsAsTextcaptcha
   class TextcaptchaConfig
+    YAML = <<~CONFIG
+      development: &common_settings
+        api_key: 'TEXTCAPTCHA_API_IDENT' # see http://textcaptcha.com for details
+        # api_endpoint: nil        # Optional API URL to fetch questions and answers from
+        # raise_errors: false      # Optional flag, if true errors will be raised if the API endpoint fails
+        # cache_expiry_minutes: 10 # Optional minutes for captcha answers to persist in the cache (default 10 minutes)
 
-    YAML = <<-CONFIG
-development: &common_settings
-  api_key: 'TEXTCAPTCHA_API_IDENT' # see http://textcaptcha.com for details
-  # api_endpoint: nil        # Optional API URL to fetch questions and answers from
-  # raise_errors: false      # Optional flag, if true errors will be raised if the API endpoint fails
-  # cache_expiry_minutes: 10 # Optional minutes for captcha answers to persist in the cache (default 10 minutes)
+        questions:
+            - question: 'Is ice hot or cold?'
+              answers: 'cold'
+            - question: 'what color is an orange?'
+              answers: 'orange'
+            - question: 'what is two plus 3?'
+              answers: '5,five'
+            - question: 'what is 5 times two?'
+              answers: '10,ten'
+            - question: 'How many colors in the list, green, brown, foot and blue?'
+              answers: '3,three'
+            - question: 'what is Georges name?'
+              answers: 'george'
+            - question: '11 minus 1?'
+              answers: '10,ten'
+            - question: 'is boiling water hot or cold?'
+              answers: 'hot'
+            - question: 'what color is my blue shirt today?'
+              answers: 'blue'
+            - question: 'what is 16 plus 4?'
+              answers: '20,twenty'
 
-  questions:
-      - question: 'Is ice hot or cold?'
-        answers: 'cold'
-      - question: 'what color is an orange?'
-        answers: 'orange'
-      - question: 'what is two plus 3?'
-        answers: '5,five'
-      - question: 'what is 5 times two?'
-        answers: '10,ten'
-      - question: 'How many colors in the list, green, brown, foot and blue?'
-        answers: '3,three'
-      - question: 'what is Georges name?'
-        answers: 'george'
-      - question: '11 minus 1?'
-        answers: '10,ten'
-      - question: 'is boiling water hot or cold?'
-        answers: 'hot'
-      - question: 'what color is my blue shirt today?'
-        answers: 'blue'
-      - question: 'what is 16 plus 4?'
-        answers: '20,twenty'
+      test:
+        <<: *common_settings
+        api_key: 'TEST_TEXTCAPTCHA_API_IDENT'
 
-test:
-  <<: *common_settings
-  api_key: 'TEST_TEXTCAPTCHA_API_IDENT'
+      production:
+        <<: *common_settings
+    CONFIG
 
-production:
-  <<: *common_settings
-CONFIG
-
-    def self.create(path: './config/textcaptcha.yml')
+    def self.create(path: "./config/textcaptcha.yml")
       FileUtils.mkdir_p(File.dirname(path))
-      File.open(path, 'w') { |f| f.write(YAML) }
+      File.open(path, "w") { |f| f.write(YAML) }
     end
   end
 end

--- a/lib/acts_as_textcaptcha/textcaptcha_helper.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_helper.rb
@@ -2,12 +2,15 @@
 
 module ActsAsTextcaptcha
   module TextcaptchaHelper
+    # rubocop:disable Naming/MethodParameterName
     def textcaptcha_fields(f, &block)
       build_textcaptcha_form_elements(f, &block) if f.object.perform_textcaptcha? && f.object.textcaptcha_key
     end
+    # rubocop:enable Naming/MethodParameterName
 
     private
 
+    # rubocop:disable Naming/MethodParameterName
     def build_textcaptcha_form_elements(f, &block)
       captcha_html = f.hidden_field(:textcaptcha_key)
       if f.object.textcaptcha_question
@@ -18,4 +21,5 @@ module ActsAsTextcaptcha
       captcha_html.html_safe
     end
   end
+  # rubocop:enable Naming/MethodParameterName
 end

--- a/lib/acts_as_textcaptcha/textcaptcha_helper.rb
+++ b/lib/acts_as_textcaptcha/textcaptcha_helper.rb
@@ -2,23 +2,20 @@
 
 module ActsAsTextcaptcha
   module TextcaptchaHelper
-
     def textcaptcha_fields(f, &block)
-      if f.object.perform_textcaptcha? && f.object.textcaptcha_key
-        build_textcaptcha_form_elements(f, &block)
-      end
+      build_textcaptcha_form_elements(f, &block) if f.object.perform_textcaptcha? && f.object.textcaptcha_key
     end
 
     private
 
-      def build_textcaptcha_form_elements(f, &block)
-        captcha_html = f.hidden_field(:textcaptcha_key)
-        if f.object.textcaptcha_question
-          captcha_html += capture(&block)
-        elsif f.object.textcaptcha_answer
-          captcha_html += f.hidden_field(:textcaptcha_answer)
-        end
-        captcha_html.html_safe
+    def build_textcaptcha_form_elements(f, &block)
+      captcha_html = f.hidden_field(:textcaptcha_key)
+      if f.object.textcaptcha_question
+        captcha_html += capture(&block)
+      elsif f.object.textcaptcha_answer
+        captcha_html += f.hidden_field(:textcaptcha_answer)
       end
+      captcha_html.html_safe
+    end
   end
 end

--- a/lib/acts_as_textcaptcha/version.rb
+++ b/lib/acts_as_textcaptcha/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ActsAsTextcaptcha
-  VERSION = '4.5.1'
+  VERSION = "4.5.1"
 end

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -1,7 +1,5 @@
 # build config file (used by some models) from template if it does not exist
-unless File.exist?('./config/textcaptcha.yml')
-  ActsAsTextcaptcha::TextcaptchaConfig.create
-end
+ActsAsTextcaptcha::TextcaptchaConfig.create unless File.exist?("./config/textcaptcha.yml")
 
 # models for use in tests
 class ApplicationRecord < ActiveRecord::Base
@@ -15,7 +13,7 @@ end
 
 class Comment < ApplicationRecord
   # inline options (symbol keys) with api_key only
-  acts_as_textcaptcha api_key: 'api_key'
+  acts_as_textcaptcha api_key: "api_key"
 end
 
 class CommentErrorRaiser < ApplicationRecord
@@ -30,25 +28,25 @@ end
 
 class FastComment < ApplicationRecord
   # inline options with super fast (0.006 seconds) cache expiry time
-  acts_as_textcaptcha cache_expiry_minutes: '0.0001',
-                      questions: [{ question: '1+1', answers: '2,two' }]
+  acts_as_textcaptcha cache_expiry_minutes: "0.0001",
+                      questions: [{ question: "1+1", answers: "2,two" }]
 end
 
 class Review < ApplicationRecord
   # inline options with all possible options
-  acts_as_textcaptcha api_key: 'api_key',
-                      questions: [{ question: 'The green hat is what color?', answers: 'green' }]
+  acts_as_textcaptcha api_key: "api_key",
+                      questions: [{ question: "The green hat is what color?", answers: "green" }]
 end
 
 class MovieReview < ApplicationRecord
   # inline options with string keys
-  acts_as_textcaptcha 'api_key'   => 'api_key',
-                      'questions' => [{ 'Question' => 'The green hat is what color?', 'answers' => nil }]
+  acts_as_textcaptcha "api_key" => "api_key",
+                      "questions" => [{ "Question" => "The green hat is what color?", "answers" => nil }]
 end
 
 class Note < ApplicationRecord
   # inline options (string keys) with user defined questions only (no textcaptcha service)
-  acts_as_textcaptcha 'questions' => [{ 'question' => '1+1', 'answers' => '2,two' }]
+  acts_as_textcaptcha "questions" => [{ "question" => "1+1", "answers" => "2,two" }]
 
   # allow toggling perform_textcaptcha on/off (default on)
   attr_accessor :turn_off_captcha
@@ -62,22 +60,23 @@ class Contact
   # non active record object (symbol keys), no API used
   include ActiveModel::Validations
   include ActiveModel::Conversion
-  extend  ActsAsTextcaptcha::Textcaptcha
+  extend ActsAsTextcaptcha::Textcaptcha
 
-  acts_as_textcaptcha questions: [{ question: 'one+1', answers: "2,two,апельсин" }]
+  acts_as_textcaptcha questions: [{ question: "one+1", answers: "2,two,апельсин" }]
 end
 
 class StrongAccessibleWidget < ApplicationRecord
   # stub out attr_accessbile interface for testing
   def self.accessible_attributes(role = :default); end
+
   def self.attr_accessible(*args); end
 
-  acts_as_textcaptcha 'questions' => [{ 'question' => '1+1', 'answers' => '2,two' }]
+  acts_as_textcaptcha "questions" => [{ "question" => "1+1", "answers" => "2,two" }]
 end
 
 class StrongProtectedWidget < StrongAccessibleWidget
   # stub out attr_protected interface for testing
   def self.attr_protected(*args); end
 
-  acts_as_textcaptcha 'questions' => [{ 'question' => '1+1', 'answers' => '2,two' }]
+  acts_as_textcaptcha "questions" => [{ "question" => "1+1", "answers" => "2,two" }]
 end

--- a/test/helpers/models.rb
+++ b/test/helpers/models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # build config file (used by some models) from template if it does not exist
 ActsAsTextcaptcha::TextcaptchaConfig.create unless File.exist?("./config/textcaptcha.yml")
 

--- a/test/helpers/rails.rb
+++ b/test/helpers/rails.rb
@@ -17,4 +17,4 @@ ENV["RAILS_ENV"] = "test"
 # initialize db with schema
 FileUtils.mkdir_p "./tmp"
 ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "tmp/acts_as_textcaptcha_test.sqlite3.db")
-load(File.expand_path(File.dirname(__FILE__) + "./../schema.rb"))
+load(File.expand_path("#{File.dirname(__FILE__)}/../schema.rb"))

--- a/test/helpers/rails.rb
+++ b/test/helpers/rails.rb
@@ -1,18 +1,18 @@
-require 'rails/all'
+require "rails/all"
 
- # init cache, StringIO logger, and test models/db
+# init cache, StringIO logger, and test models/db
 LOGGER_IO = StringIO.new
 Rails.logger = Logger.new(LOGGER_IO)
-if Rails.version >= '4'
+if Rails.version >= "4"
   Rails.cache = ActiveSupport::Cache::MemoryStore.new
 else
   RAILS_CACHE = ActiveSupport::Cache::MemoryStore.new
 end
 
 # set Rails test env
-ENV['RAILS_ENV'] = 'test'
+ENV["RAILS_ENV"] = "test"
 
 # initialize db with schema
-FileUtils.mkdir_p './tmp'
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'tmp/acts_as_textcaptcha_test.sqlite3.db')
-load(File.expand_path(File.dirname(__FILE__) + './../schema.rb'))
+FileUtils.mkdir_p "./tmp"
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: "tmp/acts_as_textcaptcha_test.sqlite3.db")
+load(File.expand_path(File.dirname(__FILE__) + "./../schema.rb"))

--- a/test/helpers/rails.rb
+++ b/test/helpers/rails.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/all"
 
 # init cache, StringIO logger, and test models/db

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveRecord::Schema.define(version: 0) do
-
   create_table :widgets, force: true do |t|
     t.string :name
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + './../lib/acts_as_textcaptcha'))
+$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + "./../lib/acts_as_textcaptcha"))
 
 # testing libs
-require 'simplecov' if ENV['COVERAGE']
-require 'minitest/autorun'
-require 'webmock/minitest'
-require './test/helpers/rails'
-require 'acts_as_textcaptcha'
-require './test/helpers/models'
+require "simplecov" if ENV["COVERAGE"]
+require "minitest/autorun"
+require "webmock/minitest"
+require "./test/helpers/rails"
+require "acts_as_textcaptcha"
+require "./test/helpers/models"
 
 # test helper methods
 
@@ -28,7 +28,7 @@ def find_in_cache(key)
   Rails.cache.read("#{ActsAsTextcaptcha::TextcaptchaCache::KEY_PREFIX}#{key}")
 end
 
-def stub_api_with(response_body, api_key: 'api_key', api_endpoint: nil, http_status: 200)
+def stub_api_with(response_body, api_key: "api_key", api_endpoint: nil, http_status: 200)
   api_endpoint ||= "http://textcaptcha.com/#{api_key}.json"
   stub_request(:get, api_endpoint).to_return(
     status: http_status,
@@ -41,6 +41,6 @@ def valid_json_response
 end
 
 def json_response(filename)
-  fixture_dir = File.expand_path(File.dirname(__FILE__)+"/fixtures/")
+  fixture_dir = File.expand_path(File.dirname(__FILE__) + "/fixtures/")
   File.read("#{fixture_dir}/responses/#{filename}")
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + "./../lib/acts_as_textcaptcha"))
+$LOAD_PATH.unshift(File.expand_path("#{File.dirname(__FILE__)}/../lib/acts_as_textcaptcha"))
 
 # testing libs
 require "simplecov" if ENV["COVERAGE"]
@@ -41,6 +41,6 @@ def valid_json_response
 end
 
 def json_response(filename)
-  fixture_dir = File.expand_path(File.dirname(__FILE__) + "/fixtures/")
+  fixture_dir = File.expand_path("#{File.dirname(__FILE__)}/fixtures/")
   File.read("#{fixture_dir}/responses/#{filename}")
 end

--- a/test/textcaptcha_api_test.rb
+++ b/test/textcaptcha_api_test.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
-
   def test_raises_error_for_invalid_api_key
     bad_key = "x b a d"
     error = assert_raises(ActsAsTextcaptcha::ApiKeyError) do
       textcaptcha_api(api_key: bad_key).fetch
     end
-    assert_match(/^Api key \'#{bad_key}\' is invalid/, error.message)
+    assert_match(/^Api key '#{bad_key}' is invalid/, error.message)
   end
 
   def test_fetch_and_parse_q_and_a
@@ -33,9 +32,9 @@ class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
       Errno::EHOSTUNREACH, EOFError, Errno::ECONNREFUSED, Errno::ETIMEDOUT,
       Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError
     ].each do |error|
-      stub_request(:get, /http:\/\/textcaptcha.com/).to_raise(error)
+      stub_request(:get, %r{http://textcaptcha.com}).to_raise(error)
       assert_nil textcaptcha_api.fetch
-     end
+    end
   end
 
   def test_returns_nil_when_non_200_response_code_received
@@ -50,9 +49,9 @@ class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
 
   def test_logs_error_to_rails_logger_if_raise_errors_not_set
     clear_rails_log
-    stub_request(:get, /http:\/\/textcaptcha.com/).to_raise(Timeout::Error)
+    stub_request(:get, %r{http://textcaptcha.com}).to_raise(Timeout::Error)
     textcaptcha_api(raise_errors: false).fetch
-    assert_log_matches [/ActsAsTextcaptcha::ResponseError fetching \'.*\' failed - Exception from WebMock/]
+    assert_log_matches [/ActsAsTextcaptcha::ResponseError fetching '.*' failed - Exception from WebMock/]
   end
 
   def test_returns_nil_when_empty_response_received
@@ -61,11 +60,11 @@ class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
   end
 
   def test_raises_response_error_if_raise_errors_set
-    stub_request(:get, /http:\/\/textcaptcha.com/).to_raise(Timeout::Error)
+    stub_request(:get, %r{http://textcaptcha.com}).to_raise(Timeout::Error)
     error = assert_raises(ActsAsTextcaptcha::ResponseError) do
       textcaptcha_api(raise_errors: true).fetch
     end
-    assert_match(/^fetching \'.*\' failed - Exception from WebMock/, error.message)
+    assert_match(/^fetching '.*' failed - Exception from WebMock/, error.message)
   end
 
   def test_raises_parse_error_if_raise_errors_set
@@ -73,16 +72,16 @@ class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
     error = assert_raises(ActsAsTextcaptcha::ParseError) do
       textcaptcha_api(raise_errors: true).fetch
     end
-    assert_match(/^parsing JSON from \'.*\' failed/, error.message)
+    assert_match(/^parsing JSON from '.*' failed/, error.message)
   end
 
   private
 
-    def textcaptcha_api(api_key: 'api_key', api_endpoint: nil, raise_errors: false)
-      @textcaptcha_api ||= ActsAsTextcaptcha::TextcaptchaApi.new(
-        api_key: api_key,
-        api_endpoint: api_endpoint,
-        raise_errors: raise_errors
-      )
-    end
+  def textcaptcha_api(api_key: "api_key", api_endpoint: nil, raise_errors: false)
+    @textcaptcha_api ||= ActsAsTextcaptcha::TextcaptchaApi.new(
+      api_key: api_key,
+      api_endpoint: api_endpoint,
+      raise_errors: raise_errors
+    )
+  end
 end

--- a/test/textcaptcha_api_test.rb
+++ b/test/textcaptcha_api_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class ActsAsTextcaptcha::TextcaptchaApiTest < Minitest::Test
   def test_raises_error_for_invalid_api_key

--- a/test/textcaptcha_cache_test.rb
+++ b/test/textcaptcha_cache_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class ActsAsTextcaptcha::TextcaptchaCacheTest < Minitest::Test
   def setup

--- a/test/textcaptcha_cache_test.rb
+++ b/test/textcaptcha_cache_test.rb
@@ -1,36 +1,35 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class ActsAsTextcaptcha::TextcaptchaCacheTest < Minitest::Test
-
   def setup
-    cache.write('mykey', [1,2,3])
+    cache.write("mykey", [1, 2, 3])
   end
 
   def test_reading_from_cache
-    assert_equal cache.read('mykey'), [1,2,3]
+    assert_equal cache.read("mykey"), [1, 2, 3]
   end
 
   def test_writing_to_cache
-    cache.write('my-new-key', 'abc')
-    assert_equal cache.read('my-new-key'), 'abc'
+    cache.write("my-new-key", "abc")
+    assert_equal cache.read("my-new-key"), "abc"
   end
 
   def test_deleting_from_cache
-    assert_equal cache.read('mykey'), [1,2,3]
-    cache.delete('mykey')
+    assert_equal cache.read("mykey"), [1, 2, 3]
+    cache.delete("mykey")
 
-    assert_nil cache.read('mykey')
+    assert_nil cache.read("mykey")
   end
 
   def test_cache_keys_use_a_prefix
-    assert_equal Rails.cache.read("#{ActsAsTextcaptcha::TextcaptchaCache::KEY_PREFIX}mykey"), [1,2,3]
+    assert_equal Rails.cache.read("#{ActsAsTextcaptcha::TextcaptchaCache::KEY_PREFIX}mykey"), [1, 2, 3]
   end
 
   private
 
-    def cache
-      @cache ||= ActsAsTextcaptcha::TextcaptchaCache.new
-    end
+  def cache
+    @cache ||= ActsAsTextcaptcha::TextcaptchaCache.new
+  end
 end

--- a/test/textcaptcha_config_test.rb
+++ b/test/textcaptcha_config_test.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class TextcaptchaConfigTest < Minitest::Test
-
-  CONFIG_PATH = './tmp/test/config/textcaptcha.yml'
+  CONFIG_PATH = "./tmp/test/config/textcaptcha.yml"
 
   def setup
-    FileUtils.rm_rf('./tmp/test')
+    FileUtils.rm_rf("./tmp/test")
   end
 
   def test_creates_yaml_config_file_and_path_to_it_from_example_config

--- a/test/textcaptcha_config_test.rb
+++ b/test/textcaptcha_config_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class TextcaptchaConfigTest < Minitest::Test
   CONFIG_PATH = "./tmp/test/config/textcaptcha.yml"

--- a/test/textcaptcha_config_test.rb
+++ b/test/textcaptcha_config_test.rb
@@ -14,7 +14,7 @@ class TextcaptchaConfigTest < Minitest::Test
     refute_nil ActsAsTextcaptcha::TextcaptchaConfig.create(path: CONFIG_PATH)
     assert File.exist?(CONFIG_PATH)
 
-    example_config = YAML.safe_load(File.read(CONFIG_PATH))
+    example_config = YAML.load(File.read(CONFIG_PATH))
     assert_equal example_config.keys, %w(development test production)
   end
 end

--- a/test/textcaptcha_config_test.rb
+++ b/test/textcaptcha_config_test.rb
@@ -14,7 +14,7 @@ class TextcaptchaConfigTest < Minitest::Test
     refute_nil ActsAsTextcaptcha::TextcaptchaConfig.create(path: CONFIG_PATH)
     assert File.exist?(CONFIG_PATH)
 
-    example_config = YAML.load(File.read(CONFIG_PATH))
+    example_config = YAML.safe_load(File.read(CONFIG_PATH))
     assert_equal example_config.keys, %w(development test production)
   end
 end

--- a/test/textcaptcha_config_test.rb
+++ b/test/textcaptcha_config_test.rb
@@ -14,7 +14,9 @@ class TextcaptchaConfigTest < Minitest::Test
     refute_nil ActsAsTextcaptcha::TextcaptchaConfig.create(path: CONFIG_PATH)
     assert File.exist?(CONFIG_PATH)
 
+    # rubocop:disable Security/YAMLLoad
     example_config = YAML.load(File.read(CONFIG_PATH))
+    # rubocop:enable Security/YAMLLoad
     assert_equal example_config.keys, %w(development test production)
   end
 end

--- a/test/textcaptcha_helper_test.rb
+++ b/test/textcaptcha_helper_test.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class NotesController < ActionController::Base; end
 
 class ViewTemplate < ActionView::Base
-  def protect_against_forgery?; false; end
+  def protect_against_forgery?
+    false
+  end
 end
 
 class TextcaptchaHelperTest < Minitest::Test
-
   def setup
     note.textcaptcha
   end
@@ -17,19 +18,19 @@ class TextcaptchaHelperTest < Minitest::Test
   def test_renders_q_and_a_fields_with_hidden_key_field
     html = render_template
 
-    assert_match(/\<label for\=\"note_textcaptcha_answer\"\>1\+1\<\/label\>/, html)
-    assert_match(/\<input(.*)name\=\"note\[textcaptcha_answer\]\"(.*)\/\>/, html)
-    assert_match(/\<input(.*)name\=\"note\[textcaptcha_key\]\"(.*)\/\>/, html)
+    assert_match(%r{<label for="note_textcaptcha_answer">1\+1</label>}, html)
+    assert_match(%r{<input(.*)name="note\[textcaptcha_answer\]"(.*)/>}, html)
+    assert_match(%r{<input(.*)name="note\[textcaptcha_key\]"(.*)/>}, html)
   end
 
   def test_renders_only_hidden_answer_field_when_only_answer_present
     note.textcaptcha_question = nil
-    note.textcaptcha_answer   = 2
+    note.textcaptcha_answer = 2
     html = render_template
 
-    refute_match(/\<label for\=\"note_textcaptcha_answer\"\>1\+1\<\/label\>/, html)
-    assert_match(/\<input(.*)name\=\"note\[textcaptcha_answer\]\"(.*)\/\>/, html)
-    assert_match(/\<input(.*)name\=\"note\[textcaptcha_key\]\"(.*)\/\>/, html)
+    refute_match(%r{<label for="note_textcaptcha_answer">1\+1</label>}, html)
+    assert_match(%r{<input(.*)name="note\[textcaptcha_answer\]"(.*)/>}, html)
+    assert_match(%r{<input(.*)name="note\[textcaptcha_key\]"(.*)/>}, html)
   end
 
   def test_does_not_render_q_or_a_when_perform_textcaptcha_is_false
@@ -50,13 +51,13 @@ class TextcaptchaHelperTest < Minitest::Test
 
   private
 
-    def note
-      @note ||= Note.new
-    end
+  def note
+    @note ||= Note.new
+  end
 
-    def render_template(assigns = { :note => @note })
-     @controller ||= NotesController.new
-      html_erb = <<-ERB
+  def render_template(assigns = { note: @note })
+    @controller ||= NotesController.new
+    html_erb = <<-ERB
       <%= form_for(@note, :url => '/') do |f| %>
         <%= textcaptcha_fields(f) do %>
         <div class="field textcaptcha">
@@ -65,18 +66,18 @@ class TextcaptchaHelperTest < Minitest::Test
         </div>
         <% end %>
       <% end %>
-      ERB
+    ERB
 
-      template(assigns).render(inline: html_erb)
-    end
+    template(assigns).render(inline: html_erb)
+  end
 
-    def template(assigns)
-      if Gem::Version.new(Rails.version) < Gem::Version.new(6)
-        ViewTemplate.new([], assigns, @controller)
-      else
-        ViewTemplate.with_empty_template_cache.new(
-          ActionView::LookupContext.new([]), assigns, @controller
-        )
-      end
+  def template(assigns)
+    if Gem::Version.new(Rails.version) < Gem::Version.new(6)
+      ViewTemplate.new([], assigns, @controller)
+    else
+      ViewTemplate.with_empty_template_cache.new(
+        ActionView::LookupContext.new([]), assigns, @controller
+      )
     end
+  end
 end

--- a/test/textcaptcha_helper_test.rb
+++ b/test/textcaptcha_helper_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class NotesController < ActionController::Base; end
 

--- a/test/textcaptcha_test.rb
+++ b/test/textcaptcha_test.rb
@@ -87,7 +87,7 @@ class TextcaptchaTest < Minitest::Test
     YAML.stub :load, -> { raise "bad things" } do
       exception = assert_raises(ArgumentError) do
         # using eval here, sorry :(
-        eval <<-CLASS
+        eval <<-CLASS, binding, __FILE__, __LINE__ + 1
           class SomeWidget < ApplicationRecord
             acts_as_textcaptcha
           end

--- a/test/textcaptcha_test.rb
+++ b/test/textcaptcha_test.rb
@@ -1,19 +1,18 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class TextcaptchaTest < Minitest::Test
-
   def test_answer_submitted_after_expiry_time
     comment = FastComment.new
     comment.textcaptcha
-    assert_equal comment.textcaptcha_question, '1+1'
-    comment.textcaptcha_answer = 'two'
+    assert_equal comment.textcaptcha_question, "1+1"
+    comment.textcaptcha_answer = "two"
     sleep(0.01)
 
     refute comment.valid?
     assert_equal comment.errors[:textcaptcha_answer].first,
-      'was not submitted quickly enough, try another question instead'
+                 "was not submitted quickly enough, try another question instead"
   end
 
   def test_fetches_q_and_a_from_api
@@ -21,18 +20,18 @@ class TextcaptchaTest < Minitest::Test
 
     review = Review.new
     review.textcaptcha
-    refute_equal review.textcaptcha_question, 'The green hat is what color?'
+    refute_equal review.textcaptcha_question, "The green hat is what color?"
     refute_nil review.textcaptcha_question
 
     refute_nil find_in_cache(review.textcaptcha_key)
 
     refute review.valid?
     assert_equal review.errors[:textcaptcha_answer].first,
-      'is incorrect, try another question instead'
+                 "is incorrect, try another question instead"
   end
 
   def test_parses_answers_from_json_response
-    review  = Review.new
+    review = Review.new
     stub_api_with(valid_json_response)
 
     review.textcaptcha
@@ -41,18 +40,18 @@ class TextcaptchaTest < Minitest::Test
   end
 
   def test_assigns_user_defined_question_when_api_fetch_returns_nil
-    stub_request(:get, 'http://textcaptcha.com/api_key.json').
-      and_return(body: '')
+    stub_request(:get, "http://textcaptcha.com/api_key.json")
+      .and_return(body: "")
 
     review = Review.new
     review.textcaptcha
-    assert_equal review.textcaptcha_question, 'The green hat is what color?'
+    assert_equal review.textcaptcha_question, "The green hat is what color?"
     refute_nil find_in_cache(review.textcaptcha_key)
   end
 
   def test_assigns_no_q_and_a_when_no_user_defined_question_set_and_api_fails
-    stub_request(:get, 'http://textcaptcha.com/api_key.json').
-      to_raise(SocketError)
+    stub_request(:get, "http://textcaptcha.com/api_key.json")
+      .to_raise(SocketError)
 
     comment = Comment.new
     comment.textcaptcha
@@ -61,7 +60,7 @@ class TextcaptchaTest < Minitest::Test
   end
 
   def test_assigns_no_q_and_a_when_user_defined_question_set_incorrectly_and_api_fails
-    stub_request(:get, 'http://textcaptcha.com/api_key.json')
+    stub_request(:get, "http://textcaptcha.com/api_key.json")
       .to_raise(SocketError)
 
     comment = MovieReview.new
@@ -72,15 +71,15 @@ class TextcaptchaTest < Minitest::Test
 
   def test_configuration_with_hash
     assert_equal Review.textcaptcha_config, {
-      api_key: 'api_key',
+      api_key: "api_key",
       questions: [
-        { question: 'The green hat is what color?', answers: 'green' }
+        { question: "The green hat is what color?", answers: "green" }
       ]
     }
   end
 
   def test_configuration_with_textcaptcha_yml
-    assert_equal Widget.textcaptcha_config[:api_key], 'TEST_TEXTCAPTCHA_API_IDENT'
+    assert_equal Widget.textcaptcha_config[:api_key], "TEST_TEXTCAPTCHA_API_IDENT"
     assert_equal Widget.textcaptcha_config[:questions].length, 10
   end
 

--- a/test/textcaptcha_test.rb
+++ b/test/textcaptcha_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class TextcaptchaTest < Minitest::Test
   def test_answer_submitted_after_expiry_time

--- a/test/textcaptcha_validation_test.rb
+++ b/test/textcaptcha_validation_test.rb
@@ -1,39 +1,38 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + '/test_helper')
+require File.expand_path(File.dirname(__FILE__) + "/test_helper")
 
 class TextcaptchaValidationTest < Minitest::Test
-
   def setup
     note.textcaptcha
   end
 
   def test_validates_with_correct_answers
-    assert_equal note.textcaptcha_question, '1+1'
+    assert_equal note.textcaptcha_question, "1+1"
     refute note.valid?
-    assert_equal note.errors[:textcaptcha_answer].first, 'is incorrect, try another question instead'
+    assert_equal note.errors[:textcaptcha_answer].first, "is incorrect, try another question instead"
 
-    note.textcaptcha_answer = 'two'
+    note.textcaptcha_answer = "two"
     assert note.valid?
     assert note.errors[:textcaptcha_answer].empty?
 
-    note.textcaptcha_answer = '2'
+    note.textcaptcha_answer = "2"
     assert note.valid?
     assert note.errors[:textcaptcha_answer].empty?
   end
 
   def test_strips_whitespace_and_downcases_answer_to_validate
-    note.textcaptcha_answer = ' tWo '
+    note.textcaptcha_answer = " tWo "
     assert note.valid?
     assert note.errors[:textcaptcha_answer].empty?
   end
 
   def test_is_always_valid_after_record_has_been_saved
-    note.textcaptcha_answer = '2'
+    note.textcaptcha_answer = "2"
     note.save!
     note.textcaptcha
 
-    note.textcaptcha_answer = 'wrong answer'
+    note.textcaptcha_answer = "wrong answer"
     refute note.new_record?
     assert note.valid?
     assert_empty note.errors[:textcaptcha_answer]
@@ -51,11 +50,11 @@ class TextcaptchaValidationTest < Minitest::Test
     contact = Contact.new
     contact.textcaptcha
 
-    assert_equal contact.textcaptcha_question, 'one+1'
-    contact.textcaptcha_answer = 'wrong'
+    assert_equal contact.textcaptcha_question, "one+1"
+    contact.textcaptcha_answer = "wrong"
     refute contact.valid?
 
-    contact.textcaptcha_answer = 'two'
+    contact.textcaptcha_answer = "two"
     assert contact.valid?
     assert_empty contact.errors[:textcaptcha_answer]
   end
@@ -63,32 +62,32 @@ class TextcaptchaValidationTest < Minitest::Test
   def test_answer_submitted_after_expiry_time
     comment = FastComment.new
     comment.textcaptcha
-    assert_equal comment.textcaptcha_question, '1+1'
-    comment.textcaptcha_answer = 'two'
+    assert_equal comment.textcaptcha_question, "1+1"
+    comment.textcaptcha_answer = "two"
     sleep(0.01)
 
     refute comment.valid?
     assert_equal comment.errors[:textcaptcha_answer].first,
-      'was not submitted quickly enough, try another question instead'
+                 "was not submitted quickly enough, try another question instead"
   end
 
   def test_assigns_captcha_with_accessible_attr_widget
     widget = StrongAccessibleWidget.new
     widget.textcaptcha
-    assert_equal widget.textcaptcha_question, '1+1'
+    assert_equal widget.textcaptcha_question, "1+1"
     refute widget.valid?
   end
 
   def test_assigns_captcha_with_protected_attr_widget
     widget = StrongProtectedWidget.new
     widget.textcaptcha
-    assert_equal widget.textcaptcha_question, '1+1'
+    assert_equal widget.textcaptcha_question, "1+1"
     refute widget.valid?
   end
 
   private
 
-    def note
-      @note ||= Note.new
-    end
+  def note
+    @note ||= Note.new
+  end
 end

--- a/test/textcaptcha_validation_test.rb
+++ b/test/textcaptcha_validation_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path(File.dirname(__FILE__) + "/test_helper")
+require File.expand_path("#{File.dirname(__FILE__)}/test_helper")
 
 class TextcaptchaValidationTest < Minitest::Test
   def setup


### PR DESCRIPTION
Hi, 
I want to thank you for the useful gem I've used recently in a project: https://github.com/OpenSourcePolitics/decidim-module-question_captcha

I've noticed that this project didn't use a linter and it was a bit confusing for me to read it.

I've implemented Rubocop with a few rules, and refactor a few part a little.

Feel free to discuss any part of this P.R.

---
#### :memo: Checklist
- [x] Commit messages provide context (why not just what, some tips [here](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)).
- [x] Latest code from master merged.
- [x] New behaviour has test coverage.
- [x] Avoid duplicating code.
- [x] No commented out code.
- [x] Avoid comments for your code, write code that explains itself.
- [x] Changes are simple, useful, clear and brief.
